### PR TITLE
Add empty state prompt to List page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -65,7 +65,16 @@ export function App() {
 						path="/list"
 						element={listToken ? <List data={data} /> : <Navigate to="/" />}
 					/>
-					<Route path="/add-item" element={<AddItem listToken={listToken} />} />
+					<Route
+						path="/add-item"
+						element={
+							listToken ? (
+								<AddItem listToken={listToken} />
+							) : (
+								<Navigate to="/" />
+							)
+						}
+					/>
 				</Route>
 			</Routes>
 		</Router>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,19 +1,26 @@
 import { useState, useEffect } from 'react';
 import { ListItem } from '../components';
+import { useNavigate } from 'react-router-dom';
 
 export function List({ data }) {
-	// state for input
+	// State for input
 	const [input, setInput] = useState('');
 	const [searchData, setSearchData] = useState(data);
 	const [isValid, setIsValid] = useState(false);
 	const [searchLength, setSearchLength] = useState(1);
-	// Handle event
+	let navigate = useNavigate();
+
+	// Handle events
 	const handleInputChange = (e) => {
 		setInput(e.target.value);
 	};
 	const handleInputClear = () => {
 		setInput('');
 	};
+	const handleClick = () => {
+		navigate('/add-item');
+	};
+
 	useEffect(() => {
 		const searchRegex = new RegExp(
 			input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
@@ -33,30 +40,40 @@ export function List({ data }) {
 		}
 	}, [searchData, data.length]);
 
+	console.log(data);
+
 	return (
 		<>
-			<p>
-				Hello from the <code>/list</code> page!
-			</p>
-			<form>
-				Search for your item:
-				<input
-					type="text"
-					value={input}
-					onChange={handleInputChange}
-					maxLength={searchLength}
-				/>
-				{input.length > 0 && <button onClick={handleInputClear}>x</button>}
-			</form>
-			{isValid ? (
-				<ul>
-					{searchData &&
-						searchData.map((item) => (
-							<ListItem key={item.id} name={item.name} />
-						))}
-				</ul>
+			{data && data.length === 0 ? (
+				<div>
+					<h2>Your list is empty. Get started by adding an item.</h2>
+					<p>To add an item to your list, tap the Add Item button below.</p>
+
+					<button onClick={handleClick}> + Add Item </button>
+				</div>
 			) : (
-				<h2>no matches</h2>
+				<div>
+					<form>
+						Search for your item:
+						<input
+							type="text"
+							value={input}
+							onChange={handleInputChange}
+							maxLength={searchLength}
+						/>
+						{input.length > 0 && <button onClick={handleInputClear}>x</button>}
+					</form>
+					{isValid ? (
+						<ul>
+							{searchData &&
+								searchData.map((item) => (
+									<ListItem key={item.id} name={item.name} />
+								))}
+						</ul>
+					) : (
+						<h2>no matches</h2>
+					)}
+				</div>
 			)}
 		</>
 	);

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -8,7 +8,7 @@ export function List({ data }) {
 	const [searchData, setSearchData] = useState(data);
 	const [isValid, setIsValid] = useState(false);
 	const [searchLength, setSearchLength] = useState(1);
-	let navigate = useNavigate();
+	const navigate = useNavigate();
 
 	// Handle events
 	const handleInputChange = (e) => {
@@ -39,8 +39,6 @@ export function List({ data }) {
 			setSearchLength(0);
 		}
 	}, [searchData, data.length]);
-
-	console.log(data);
 
 	return (
 		<>


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description
When a user starts a new list, they need a little guidance on how to get started. We added an empty state prompt, clear instructions, and an Add Item button. 

## Related Issue
closes #7. 

## Acceptance criteria
- [x] The list view, when there are no items to display, should show a prompt (e.g., a button) for the user to add their first item

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


## Testing Steps / QA Criteria

1. Navigate to your main branch and pull all changes with `git pull`, then navigate to the feature branch ms-jc-add-getstarted-prompt. 
2. Start up your dev environment by entering `npm start`.
3. Ensure you don't have any list tokens stored in your browser's local storage. You can check by going to Inspect in your browser, tapping Application tab, and clearing any tokens listed.
4. In the application, navigate to the List page where you should see the option to create a new list - tap that button. 
5. You will then see a prompt to add your first item.
6. Click the Add Item button, which will navigate you to the Add Item page. Add your item. 
7. Navigate back to the List page, and you should now see the option to search your list.   