### PR TITLE
Mark Items As Purchased

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -62,7 +62,13 @@ export function App() {
 					/>
 					<Route
 						path="/list"
-						element={listToken ? <List data={data} /> : <Navigate to="/" />}
+						element={
+							listToken ? (
+								<List data={data} listToken={listToken} />
+							) : (
+								<Navigate to="/" />
+							)
+						}
 					/>
 					<Route path="/add-item" element={<AddItem />} />
 				</Route>

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -77,13 +77,13 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 	}
 }
 
-export async function updateItem(list, item) {
-	const collectionRef = collection(db, list);
-	const queryRef = query(collectionRef, where('name', '==', item));
-	const querySnapshot = await getDocs(queryRef);
-	const documentSnapshot = querySnapshot.docs[0];
-	const documentId = documentSnapshot.id;
-	const docRef = doc(db, list, documentId);
+export async function updateItem(list, itemId) {
+	// const collectionRef = collection(db, list);
+	// const queryRef = query(collectionRef, where('name', '==', item));
+	// const querySnapshot = await getDocs(queryRef);
+	// const documentSnapshot = querySnapshot.docs[0];
+	// const documentId = documentSnapshot.id;
+	const docRef = doc(db, list, itemId);
 	return await updateDoc(docRef, {
 		dateLastPurchased: new Date(),
 		totalPurchases: increment(1),

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -78,11 +78,6 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 }
 
 export async function updateItem(list, itemId) {
-	// const collectionRef = collection(db, list);
-	// const queryRef = query(collectionRef, where('name', '==', item));
-	// const querySnapshot = await getDocs(queryRef);
-	// const documentSnapshot = querySnapshot.docs[0];
-	// const documentId = documentSnapshot.id;
 	const docRef = doc(db, list, itemId);
 	return await updateDoc(docRef, {
 		dateLastPurchased: new Date(),

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -1,4 +1,14 @@
-import { collection, onSnapshot, addDoc } from 'firebase/firestore';
+import {
+	collection,
+	onSnapshot,
+	addDoc,
+	getDocs,
+	query,
+	where,
+	doc,
+	updateDoc,
+	increment,
+} from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
 import { getFutureDate } from '../utils';
@@ -67,12 +77,17 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 	}
 }
 
-export async function updateItem() {
-	/**
-	 * TODO: Fill this out so that it uses the correct Firestore function
-	 * to update an existing item. You'll need to figure out what arguments
-	 * this function must accept!
-	 */
+export async function updateItem(list, item) {
+	const collectionRef = collection(db, list);
+	const queryRef = query(collectionRef, where('name', '==', item));
+	const querySnapshot = await getDocs(queryRef);
+	const documentSnapshot = querySnapshot.docs[0];
+	const documentId = documentSnapshot.id;
+	const docRef = doc(db, list, documentId);
+	return await updateDoc(docRef, {
+		dateLastPurchased: new Date(),
+		totalPurchases: increment(1),
+	});
 }
 
 export async function deleteItem() {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,5 +1,5 @@
 //LIBRARY IMPORTS
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState } from 'react';
 
 // LOCAL IMPORTS
 import './ListItem.css';
@@ -7,115 +7,17 @@ import { updateItem } from '../api/firebase.js';
 
 export function ListItem({ name, listToken, dateLastPurchased, itemId }) {
 	// SET STATES
-	//[read comments on line 16 - 26 first] Rather than building in an automatic uncheck - we decided to only rely on uncheck happening on render. On render, each list item's checked state will be set by comparing the date last purchased in seconds
 	const [isChecked, setIsChecked] = useState(
-		Date.now() / 1000 - // Date.now() / 1000 gets the current time in Unix timestamp format, in seconds
-			dateLastPurchased?.seconds < // dateLastPurchased?.seconds provides the last purchase time in Unix timestamp format, in seconds
-			// Subtracting dateLastPurchased from the current time gives the time difference in seconds
-			60 * 60 * 24,
-	); // We then compare this difference with 24 hours converted to seconds (60 * 60 * 24)
-	// If the time difference is less than 24 hours, isChecked is set to true
-	// Otherwise, isChecked is set to false
-
-	// const mounted = useRef(false);
+		Date.now() / 1000 - dateLastPurchased?.seconds < 60 * 60 * 24,
+	);
 
 	// EVENT HANDLER
 	const handleCheck = () => {
-		//Moved updateItem function back into click handler, but BEFORE state setting to avoid async issues we faced earlier (rendering the first useEffect we had on line 42 unecessary)
-		//on click, if the state is NOT checked
 		if (!isChecked) {
-			//update relevant fields in Firestore
 			updateItem(listToken, itemId);
 		}
-		//and set the state (this state setting syntax helps with things like checkboxes that can be changed multiple times back to back, this syntax relies on the previously state is set before changing the state again)
 		setIsChecked((prevState) => !prevState);
 	};
-
-	//Initially we tried to simplify the 2 useEffect hooks on lines 42 and 56 into one hook here. The syntax line 28 needed to change - date objects that come from Firestore have different syntax that Javascript dates - so we needed to access the seconds property of the Firestore date object and then convert is to milliseconds. This useEffect automatically removed the checkboxes at the set time, but on the uncheck and recheck continued to be buggy because everything that was purchased less than 24 hours ago would automatically recheck on one click.
-	// useEffect(() => {
-	// 	const currentTime = new Date().getTime();
-	// 	const lastPurchasedTime = dateLastPurchased?.seconds * 1000
-	// 	const timeDifference = currentTime - lastPurchasedTime;
-	// 	const twentyFourHours = 24 * 60 * 60 * 1000;
-	// 	if (timeDifference < twentyFourHours) {
-	// 		setIsChecked(true);
-	// 		const timeLeft = twentyFourHours - timeDifference;
-	// 		// setTimeout(() => setIsChecked(false), timeLeft);
-	// 		//FOR TESTING 15 SECONDS
-	// 		setTimeout(() => setIsChecked(false), 15000);
-	// 	} else {
-	// 		setIsChecked(false);
-	// 	}
-	// }, [name, dateLastPurchased]);
-
-	// useEffect(() => {
-	// 	if (mounted.current) {
-	// 		if (isChecked) {
-	// 			//the following lines of code are copied and pasted from the above handleClick function
-	// 			// const twentyFourHours = 24 * 60 * 60 * 1000;
-	// 			// const uncheckTime = new Date().getTime() + twentyFourHours;
-	// 			// localStorage.setItem(`${name}=uncheckTime`, uncheckTime.toString());
-	// 			updateItem(listToken, itemId);
-	// 		}
-	// 	} else {
-	// 		mounted.current = true;
-	// 	}
-	// }, [isChecked, listToken, itemId]);
-
-	// useEffect(() => {
-	// 	// GET CHECKBOX STATE FROM LOCAL STORAGE
-	// 	const storedUncheckTime = localStorage.getItem(`${name}=uncheckTime`);
-	// 	const currentTime = new Date().getTime();
-
-	// 	if (storedUncheckTime && currentTime < Number(storedUncheckTime)) {
-	// 		setIsChecked(true);
-	// 		const remainingTime = Number(storedUncheckTime) - currentTime;
-	// 		// setTimeout(() => setIsChecked(false), remainingTime);
-	// 		//FOR TESTING 15 SECONDS
-	// 		setTimeout(() => setIsChecked(false), 15000);
-	// 	} else {
-	// 		// CHECK FIRESTORE FOR ITEMS NOT IN LOCAL STORAGE
-	// 		const lastPurchasedTime = new Date(dateLastPurchased).getTime();
-	// 		const timeDifference = currentTime - lastPurchasedTime;
-	// 		const twentyFourHours = 24 * 60 * 60 * 1000;
-
-	// 		if (timeDifference < twentyFourHours) {
-	// 			setIsChecked(true);
-	// 			const timeLeft = twentyFourHours - timeDifference;
-	// 			// setTimeout(() => setIsChecked(false), timeLeft);
-	// 			//FOR TESTING 15 SECONDS
-	// 			setTimeout(() => setIsChecked(false), 15000);
-	// 		} else {
-	// 			setIsChecked(false);
-	// 		}
-	// 	}
-	// }, [name, dateLastPurchased]);
-
-	// useEffect(() => {
-	// 	const currentTime = new Date().getTime();
-	// 	const lastPurchasedTime = new Date(dateLastPurchased).getTime();
-	// 	const timeDifference = currentTime - lastPurchasedTime;
-	// 	const twentyFourHours = 24 * 60 * 60 * 1000;
-	// 	if (timeDifference < twentyFourHours) {
-	// 		setIsChecked(false)
-	// 	}
-	// }, [dateLastPurchased])
-
-	// SET INTERVAL FOR UNCHECKING BOX AFTER X TIME
-	// useEffect(() => {
-	// 	let unCheckTimer;
-	// 	if (isChecked) {
-	// 		unCheckTimer = setInterval(() => {
-	// 			setIsChecked(false);
-	// 			localStorage.setItem(`${name}=isChecked`, 'false');
-	// 		}, 2000);
-	// 	}
-	// 	return () => {
-	// 		if (unCheckTimer) {
-	// 			clearTimeout(unCheckTimer);
-	// 		}
-	// 	};
-	// }, [isChecked, name]);
 
 	return (
 		<li className="ListItem">

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -5,7 +5,7 @@ import React, { useState, useEffect } from 'react';
 import './ListItem.css';
 import { updateItem } from '../api/firebase.js';
 
-export function ListItem({ name, listToken, dateLastPurchased }) {
+export function ListItem({ name, listToken, dateLastPurchased, itemId }) {
 	// SET STATES
 	const [isChecked, setIsChecked] = useState(false);
 
@@ -16,7 +16,7 @@ export function ListItem({ name, listToken, dateLastPurchased }) {
 		const twentyFourHours = 24 * 60 * 60 * 1000;
 		const uncheckTime = new Date().getTime() + twentyFourHours;
 		// setIsChecked(!isChecked);
-		await updateItem(listToken, e.target.name);
+		await updateItem(listToken, itemId);
 		localStorage.setItem(`${name}=uncheckTime`, uncheckTime.toString());
 	};
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -11,17 +11,28 @@ export function ListItem({ name, listToken, dateLastPurchased, itemId }) {
 
 	// EVENT HANDLER
 	const handleCheck = async (e) => {
-		const currentIsChecked = !isChecked;
-		setIsChecked(currentIsChecked);
-		const twentyFourHours = 24 * 60 * 60 * 1000;
-		const uncheckTime = new Date().getTime() + twentyFourHours;
-		// setIsChecked(!isChecked);
-		await updateItem(listToken, itemId);
-		localStorage.setItem(`${name}=uncheckTime`, uncheckTime.toString());
+		// const currentIsChecked = !isChecked;
+		// setIsChecked(currentIsChecked);
+		setIsChecked(!isChecked);
+		//NOTE: since state setting is async, if something needs to happen after the state is set is should happen in a useEffect hook with the state set as a dependency, I moved the following lines down to a new useEffect
+		// const twentyFourHours = 24 * 60 * 60 * 1000;
+		// const uncheckTime = new Date().getTime() + twentyFourHours;
+		// await updateItem(listToken, itemId);
+		// localStorage.setItem(`${name}=uncheckTime`, uncheckTime.toString());
 	};
 
-	// STORE CHECKBOX STATE IN LOCALSTORAGE
 	useEffect(() => {
+		if (isChecked) {
+			//the following lines of code are copied and pasted from the above handleClick function
+			const twentyFourHours = 24 * 60 * 60 * 1000;
+			const uncheckTime = new Date().getTime() + twentyFourHours;
+			localStorage.setItem(`${name}=uncheckTime`, uncheckTime.toString());
+			updateItem(listToken, itemId);
+		}
+	}, [isChecked, listToken, itemId, name]);
+
+	useEffect(() => {
+		// STORE CHECKBOX STATE IN LOCALSTORAGE
 		const storedUncheckTime = localStorage.getItem(`${name}=uncheckTime`);
 		const currentTime = new Date().getTime();
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -7,56 +7,89 @@ import { updateItem } from '../api/firebase.js';
 
 export function ListItem({ name, listToken, dateLastPurchased, itemId }) {
 	// SET STATES
-	const [isChecked, setIsChecked] = useState(false);
-	const mounted = useRef(false);
+	//[read comments on line 16 - 26 first] Rather than building in an automatic uncheck - we decided to only rely on uncheck happening on render. On render, each list item's checked state will be set by comparing the date last purchased in seconds
+	const [isChecked, setIsChecked] = useState(
+		Date.now() / 1000 - // Date.now() / 1000 gets the current time in Unix timestamp format, in seconds
+			dateLastPurchased?.seconds < // dateLastPurchased?.seconds provides the last purchase time in Unix timestamp format, in seconds
+			// Subtracting dateLastPurchased from the current time gives the time difference in seconds
+			60 * 60 * 24,
+	); // We then compare this difference with 24 hours converted to seconds (60 * 60 * 24)
+	// If the time difference is less than 24 hours, isChecked is set to true
+	// Otherwise, isChecked is set to false
+
+	// const mounted = useRef(false);
 
 	// EVENT HANDLER
 	const handleCheck = () => {
-		setIsChecked(!isChecked);
+		//Moved updateItem function back into click handler, but BEFORE state setting to avoid async issues we faced earlier (rendering the first useEffect we had on line 42 unecessary)
+		//on click, if the state is NOT checked
+		if (!isChecked) {
+			//update relevant fields in Firestore
+			updateItem(listToken, itemId);
+		}
+		//and set the state (this state setting syntax helps with things like checkboxes that can be changed multiple times back to back, this syntax relies on the previously state is set before changing the state again)
+		setIsChecked((prevState) => !prevState);
 	};
 
-	useEffect(() => {
-		if (mounted.current) {
-			if (isChecked) {
-				//the following lines of code are copied and pasted from the above handleClick function
-				const twentyFourHours = 24 * 60 * 60 * 1000;
-				const uncheckTime = new Date().getTime() + twentyFourHours;
-				localStorage.setItem(`${name}=uncheckTime`, uncheckTime.toString());
-				updateItem(listToken, itemId);
-			}
-		} else {
-			mounted.current = true;
-		}
-	}, [isChecked, listToken, itemId, name]);
+	//Initially we tried to simplify the 2 useEffect hooks on lines 42 and 56 into one hook here. The syntax line 28 needed to change - date objects that come from Firestore have different syntax that Javascript dates - so we needed to access the seconds property of the Firestore date object and then convert is to milliseconds. This useEffect automatically removed the checkboxes at the set time, but on the uncheck and recheck continued to be buggy because everything that was purchased less than 24 hours ago would automatically recheck on one click.
+	// useEffect(() => {
+	// 	const currentTime = new Date().getTime();
+	// 	const lastPurchasedTime = dateLastPurchased?.seconds * 1000
+	// 	const timeDifference = currentTime - lastPurchasedTime;
+	// 	const twentyFourHours = 24 * 60 * 60 * 1000;
+	// 	if (timeDifference < twentyFourHours) {
+	// 		setIsChecked(true);
+	// 		const timeLeft = twentyFourHours - timeDifference;
+	// 		// setTimeout(() => setIsChecked(false), timeLeft);
+	// 		//FOR TESTING 15 SECONDS
+	// 		setTimeout(() => setIsChecked(false), 15000);
+	// 	} else {
+	// 		setIsChecked(false);
+	// 	}
+	// }, [name, dateLastPurchased]);
 
-	useEffect(() => {
-		// GET CHECKBOX STATE FROM LOCAL STORAGE
-		const storedUncheckTime = localStorage.getItem(`${name}=uncheckTime`);
-		const currentTime = new Date().getTime();
+	// useEffect(() => {
+	// 	if (mounted.current) {
+	// 		if (isChecked) {
+	// 			//the following lines of code are copied and pasted from the above handleClick function
+	// 			// const twentyFourHours = 24 * 60 * 60 * 1000;
+	// 			// const uncheckTime = new Date().getTime() + twentyFourHours;
+	// 			// localStorage.setItem(`${name}=uncheckTime`, uncheckTime.toString());
+	// 			updateItem(listToken, itemId);
+	// 		}
+	// 	} else {
+	// 		mounted.current = true;
+	// 	}
+	// }, [isChecked, listToken, itemId]);
 
-		if (storedUncheckTime && currentTime < Number(storedUncheckTime)) {
-			setIsChecked(true);
-			const remainingTime = Number(storedUncheckTime) - currentTime;
-			// setTimeout(() => setIsChecked(false), remainingTime);
-			//FOR TESTING 15 SECONDS
-			setTimeout(() => setIsChecked(false), 15000);
-		} else {
-			// CHECK FIRESTORE FOR ITEMS NOT IN LOCAL STORAGE
-			const lastPurchasedTime = new Date(dateLastPurchased).getTime();
-			const timeDifference = currentTime - lastPurchasedTime;
-			const twentyFourHours = 24 * 60 * 60 * 1000;
+	// useEffect(() => {
+	// 	// GET CHECKBOX STATE FROM LOCAL STORAGE
+	// 	const storedUncheckTime = localStorage.getItem(`${name}=uncheckTime`);
+	// 	const currentTime = new Date().getTime();
 
-			if (timeDifference < twentyFourHours) {
-				setIsChecked(true);
-				const timeLeft = twentyFourHours - timeDifference;
-				// setTimeout(() => setIsChecked(false), timeLeft);
-				//FOR TESTING 15 SECONDS
-				setTimeout(() => setIsChecked(false), 15000);
-			} else {
-				setIsChecked(false);
-			}
-		}
-	}, [name, dateLastPurchased]);
+	// 	if (storedUncheckTime && currentTime < Number(storedUncheckTime)) {
+	// 		setIsChecked(true);
+	// 		const remainingTime = Number(storedUncheckTime) - currentTime;
+	// 		// setTimeout(() => setIsChecked(false), remainingTime);
+	// 		//FOR TESTING 15 SECONDS
+	// 		setTimeout(() => setIsChecked(false), 15000);
+	// 	} else {
+	// 		// CHECK FIRESTORE FOR ITEMS NOT IN LOCAL STORAGE
+	// 		const lastPurchasedTime = new Date(dateLastPurchased).getTime();
+	// 		const timeDifference = currentTime - lastPurchasedTime;
+	// 		const twentyFourHours = 24 * 60 * 60 * 1000;
+
+	// 		if (timeDifference < twentyFourHours) {
+	// 			setIsChecked(true);
+	// 			const timeLeft = twentyFourHours - timeDifference;
+	// 			// setTimeout(() => setIsChecked(false), timeLeft);
+	// 			//FOR TESTING 15 SECONDS
+	// 			setTimeout(() => setIsChecked(false), 15000);
+	// 		} else {
+	// 			setIsChecked(false);
+	// 		}
+	// 	}
+	// }, [name, dateLastPurchased]);
 
 	// useEffect(() => {
 	// 	const currentTime = new Date().getTime();

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,5 +1,30 @@
-import './ListItem.css';
+//LIBRARY IMPORTS
+import React, { useState } from 'react';
 
-export function ListItem({ name }) {
-	return <li className="ListItem">{name}</li>;
+// LOCAL IMPORTS
+import './ListItem.css';
+import { updateItem } from '../api/firebase.js';
+
+export function ListItem({ name, listToken }) {
+	// SET STATES
+	const [isChecked, setIsChecked] = useState(false);
+
+	// EVENT HANDLER
+	const handleCheck = async (e) => {
+		setIsChecked(!isChecked);
+		await updateItem(listToken, e.target.name);
+	};
+
+	return (
+		<li className="ListItem">
+			<input
+				type="checkbox"
+				id={name}
+				name={name}
+				checked={isChecked}
+				onChange={handleCheck}
+			/>
+			<label htmlFor={name}> {name} </label>
+		</li>
+	);
 }

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -11,51 +11,36 @@ export function ListItem({ name, listToken, dateLastPurchased }) {
 
 	// EVENT HANDLER
 	const handleCheck = async (e) => {
-		// added this variable to correctly store the value of the state
 		const currentIsChecked = !isChecked;
 		setIsChecked(currentIsChecked);
 		await updateItem(listToken, e.target.name);
-		// added this line and the useEffect beneath it to store the state of the checkbox in the local storage (it was resetting upon page refreshes before)
 		localStorage.setItem(
 			`${name}=isChecked`,
 			currentIsChecked ? 'true' : 'false',
 		);
 	};
-	// maintains the state of the checkbox despite refreshes
+
 	useEffect(() => {
-		const storedCheck = localStorage.getItem(`isChecked-${name}`);
+		const storedCheck = localStorage.getItem(`${name}=isChecked`);
 		if (storedCheck !== null) {
 			setIsChecked(storedCheck === 'true');
 		}
 	}, [name]);
-	// useEffect to set an interval of time for the checkbox to uncheck itself. I read the MDN documentation you sent on setTimeout and it was very helpful (ty), that doc recommended using setInterval for our purposes
-	useEffect(() => {
-		//declare variable for timer
-		let unCheckTimer;
 
-		// check state of checkbox
+	useEffect(() => {
+		let unCheckTimer;
 		if (isChecked) {
 			unCheckTimer = setInterval(() => {
-				// state checkbox should be after desired interval
 				setIsChecked(false);
-				// desired interval, presently set to 2 seconds for testing puposes
+				localStorage.setItem(`${name}=isChecked`, 'false');
 			}, 2000);
 		}
-		// clears the timer so it will run again if checked after !isChecked is true again
 		return () => {
-			if (unCheckTimer) clearTimeout(unCheckTimer);
+			if (unCheckTimer) {
+				clearTimeout(unCheckTimer);
+			}
 		};
-	}, [isChecked]);
-	// useEffect(() => {
-	// 	const currentTime = new Date().getTime();
-	// 	const lastPurchasedTime = new Date(dateLastPurchased).getTime();
-	// 	const timeDifference = currentTime - lastPurchasedTime;
-	// 	const twentyFourHours = 24 * 60 * 60 * 1000;
-	// 	if (timeDifference < twentyFourHours) {
-	// 		setIsChecked(false)
-	// 	}
-
-	// })
+	}, [isChecked, name]);
 
 	return (
 		<li className="ListItem">

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -14,7 +14,7 @@ export function ListItem({ name, listToken, dateLastPurchased, itemId }) {
 		// const currentIsChecked = !isChecked;
 		// setIsChecked(currentIsChecked);
 		setIsChecked(!isChecked);
-		//NOTE: since state setting is async, if something needs to happen after the state is set is should happen in a useEffect hook with the state set as a dependency, I moved the following lines down to a new useEffect
+		//NOTE: since state setting is async, if something needs to happen after the state is set it should happen in a useEffect hook with the state set as a dependency, I moved the following lines down to a new useEffect
 		// const twentyFourHours = 24 * 60 * 60 * 1000;
 		// const uncheckTime = new Date().getTime() + twentyFourHours;
 		// await updateItem(listToken, itemId);
@@ -32,7 +32,7 @@ export function ListItem({ name, listToken, dateLastPurchased, itemId }) {
 	}, [isChecked, listToken, itemId, name]);
 
 	useEffect(() => {
-		// STORE CHECKBOX STATE IN LOCALSTORAGE
+		// GET CHECKBOX STATE FROM LOCAL STORAGE
 		const storedUncheckTime = localStorage.getItem(`${name}=uncheckTime`);
 		const currentTime = new Date().getTime();
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -20,6 +20,7 @@ export function ListItem({ name, listToken, dateLastPurchased }) {
 		);
 	};
 
+	// STORE CHECKBOX STATE IN LOCALSTORAGE
 	useEffect(() => {
 		const storedCheck = localStorage.getItem(`${name}=isChecked`);
 		if (storedCheck !== null) {
@@ -27,6 +28,7 @@ export function ListItem({ name, listToken, dateLastPurchased }) {
 		}
 	}, [name]);
 
+	// SET INTERVAL FOR UNCHECKING BOX AFTER X TIME
 	useEffect(() => {
 		let unCheckTimer;
 		if (isChecked) {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,5 +1,5 @@
 //LIBRARY IMPORTS
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 // LOCAL IMPORTS
 import './ListItem.css';
@@ -8,26 +8,24 @@ import { updateItem } from '../api/firebase.js';
 export function ListItem({ name, listToken, dateLastPurchased, itemId }) {
 	// SET STATES
 	const [isChecked, setIsChecked] = useState(false);
+	const mounted = useRef(false);
 
 	// EVENT HANDLER
-	const handleCheck = async (e) => {
-		// const currentIsChecked = !isChecked;
-		// setIsChecked(currentIsChecked);
+	const handleCheck = () => {
 		setIsChecked(!isChecked);
-		//NOTE: since state setting is async, if something needs to happen after the state is set it should happen in a useEffect hook with the state set as a dependency, I moved the following lines down to a new useEffect
-		// const twentyFourHours = 24 * 60 * 60 * 1000;
-		// const uncheckTime = new Date().getTime() + twentyFourHours;
-		// await updateItem(listToken, itemId);
-		// localStorage.setItem(`${name}=uncheckTime`, uncheckTime.toString());
 	};
 
 	useEffect(() => {
-		if (isChecked) {
-			//the following lines of code are copied and pasted from the above handleClick function
-			const twentyFourHours = 24 * 60 * 60 * 1000;
-			const uncheckTime = new Date().getTime() + twentyFourHours;
-			localStorage.setItem(`${name}=uncheckTime`, uncheckTime.toString());
-			updateItem(listToken, itemId);
+		if (mounted.current) {
+			if (isChecked) {
+				//the following lines of code are copied and pasted from the above handleClick function
+				const twentyFourHours = 24 * 60 * 60 * 1000;
+				const uncheckTime = new Date().getTime() + twentyFourHours;
+				localStorage.setItem(`${name}=uncheckTime`, uncheckTime.toString());
+				updateItem(listToken, itemId);
+			}
+		} else {
+			mounted.current = true;
 		}
 	}, [isChecked, listToken, itemId, name]);
 
@@ -39,7 +37,9 @@ export function ListItem({ name, listToken, dateLastPurchased, itemId }) {
 		if (storedUncheckTime && currentTime < Number(storedUncheckTime)) {
 			setIsChecked(true);
 			const remainingTime = Number(storedUncheckTime) - currentTime;
-			setTimeout(() => setIsChecked(false), remainingTime);
+			// setTimeout(() => setIsChecked(false), remainingTime);
+			//FOR TESTING 15 SECONDS
+			setTimeout(() => setIsChecked(false), 15000);
 		} else {
 			// CHECK FIRESTORE FOR ITEMS NOT IN LOCAL STORAGE
 			const lastPurchasedTime = new Date(dateLastPurchased).getTime();
@@ -49,7 +49,9 @@ export function ListItem({ name, listToken, dateLastPurchased, itemId }) {
 			if (timeDifference < twentyFourHours) {
 				setIsChecked(true);
 				const timeLeft = twentyFourHours - timeDifference;
-				setTimeout(() => setIsChecked(false), timeLeft);
+				// setTimeout(() => setIsChecked(false), timeLeft);
+				//FOR TESTING 15 SECONDS
+				setTimeout(() => setIsChecked(false), 15000);
 			} else {
 				setIsChecked(false);
 			}

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,19 +1,61 @@
 //LIBRARY IMPORTS
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 // LOCAL IMPORTS
 import './ListItem.css';
 import { updateItem } from '../api/firebase.js';
 
-export function ListItem({ name, listToken }) {
+export function ListItem({ name, listToken, dateLastPurchased }) {
 	// SET STATES
 	const [isChecked, setIsChecked] = useState(false);
 
 	// EVENT HANDLER
 	const handleCheck = async (e) => {
-		setIsChecked(!isChecked);
+		// added this variable to correctly store the value of the state
+		const currentIsChecked = !isChecked;
+		setIsChecked(currentIsChecked);
 		await updateItem(listToken, e.target.name);
+		// added this line and the useEffect beneath it to store the state of the checkbox in the local storage (it was resetting upon page refreshes before)
+		localStorage.setItem(
+			`${name}=isChecked`,
+			currentIsChecked ? 'true' : 'false',
+		);
 	};
+	// maintains the state of the checkbox despite refreshes
+	useEffect(() => {
+		const storedCheck = localStorage.getItem(`isChecked-${name}`);
+		if (storedCheck !== null) {
+			setIsChecked(storedCheck === 'true');
+		}
+	}, [name]);
+	// useEffect to set an interval of time for the checkbox to uncheck itself. I read the MDN documentation you sent on setTimeout and it was very helpful (ty), that doc recommended using setInterval for our purposes
+	useEffect(() => {
+		//declare variable for timer
+		let unCheckTimer;
+
+		// check state of checkbox
+		if (isChecked) {
+			unCheckTimer = setInterval(() => {
+				// state checkbox should be after desired interval
+				setIsChecked(false);
+				// desired interval, presently set to 2 seconds for testing puposes
+			}, 2000);
+		}
+		// clears the timer so it will run again if checked after !isChecked is true again
+		return () => {
+			if (unCheckTimer) clearTimeout(unCheckTimer);
+		};
+	}, [isChecked]);
+	// useEffect(() => {
+	// 	const currentTime = new Date().getTime();
+	// 	const lastPurchasedTime = new Date(dateLastPurchased).getTime();
+	// 	const timeDifference = currentTime - lastPurchasedTime;
+	// 	const twentyFourHours = 24 * 60 * 60 * 1000;
+	// 	if (timeDifference < twentyFourHours) {
+	// 		setIsChecked(false)
+	// 	}
+
+	// })
 
 	return (
 		<li className="ListItem">

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -52,8 +52,14 @@ export function List({ data, listToken }) {
 				<ul>
 					{searchData &&
 						searchData.map((item) => (
-							<ListItem key={item.id} name={item.name} listToken={listToken} />
+							<ListItem
+								key={item.id}
+								name={item.name}
+								dateLastPurchased={item.dateLastPurchased}
+								listToken={listToken}
+							/>
 						))}
+					{/* <button onClick={console.log({item})}>c</button> */}
 				</ul>
 			) : (
 				<h2>no matches</h2>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { ListItem } from '../components';
 
-export function List({ data }) {
+export function List({ data, listToken }) {
 	// state for input
 	const [input, setInput] = useState('');
 	const [searchData, setSearchData] = useState(data);
@@ -52,7 +52,7 @@ export function List({ data }) {
 				<ul>
 					{searchData &&
 						searchData.map((item) => (
-							<ListItem key={item.id} name={item.name} />
+							<ListItem key={item.id} name={item.name} listToken={listToken} />
 						))}
 				</ul>
 			) : (

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -59,7 +59,6 @@ export function List({ data, listToken }) {
 								listToken={listToken}
 							/>
 						))}
-					{/* <button onClick={console.log({item})}>c</button> */}
 				</ul>
 			) : (
 				<h2>no matches</h2>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -54,6 +54,7 @@ export function List({ data, listToken }) {
 						searchData.map((item) => (
 							<ListItem
 								key={item.id}
+								itemId={item.id}
 								name={item.name}
 								dateLastPurchased={item.dateLastPurchased}
 								listToken={listToken}


### PR DESCRIPTION
## Description

Users need a UI that allows them to mark the their items as purchased, so they can track what on their list they do and do not need to buy.
This PR updates the the list view to include checkboxes next to each List Item so users can track if they still need to purchase it. Checking the box updates the Firebase data fields of dateLastPurchased and totalPurchases. After 24 hours the checkbox will uncheck, allowing the user to check it again for future purchases.

## Related Issue

closes #8 

## Acceptance Criteria

- [x] The ListItem component renders a checkbox with a semantic <label>.
- [x] Checking off the item in the UI also updates the dateLastPurchased and totalPurchases properties on the corresponding Firestore document
- [x] The item is shown as checked for 24 hours after the purchase is made (i.e. we assume the user does not need to buy the item again for at least 1 day). After 24 hours, the item unchecks itself so the user can buy it again.
- [x] The updateItem function in firebase.js has been filled out, and sends updates to the firestore database when an item is checked or un-checked

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![issue8before](https://github.com/the-collab-lab/tcl-62-smart-shopping-list/assets/92347861/055f2213-9c9a-4b9a-8286-b00e9ff63d3a)


### After

![issue8after](https://github.com/the-collab-lab/tcl-62-smart-shopping-list/assets/92347861/8488b162-75cc-459b-9d36-93cb4ea78383)

## Testing Steps / QA Criteria

1. Run `git fetch` and `git pull` in the terminal on the main branch to retrieve all updates, then switch to feature branch with `git checkout as-hs-mark-purchased`
2. Run the dev environment with `npm start`
3. In the browser, clear the list token stored in your local storage. Refresh the page and create a new list. Note the list token.
4. In a new tab, navigate to Firestore and open the list.
5. Back in the application tab, navigate to 'Add Item' and add 3-5 items to your list.
6. Navigate back to the list view. Click the checkboxes next to a couple items on your list. 
8. In Firestore, verify that the dateLastPurchased and the totalPurchases fields for those checked items have been updated from 'null' and 0 to the current date and time and 1.
9. Refresh your list view, the same items should continue to be checked.
10. Now edit the dateLastPurchased field in Firestore for your checked items. Change the date and time to a date and time that is at least 24 hours earlier than the current time. For example, if the dateLastPurchased is listed set as "September 7, 2023 at 9:05:06 AM", make sure the new time is no sooner than "September 6, 2023 at 9:05:06 AM" 
11. Navigate back to the browser and refresh the page. The checkboxes next to those purchased items should now be unchecked. 