### PR TITLE
Estimate Next Purchase Date

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -11,7 +11,7 @@ import {
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
-import { getFutureDate } from '../utils';
+import { getFutureDate, getDaysBetweenDates } from '../utils';
 
 /**
  * A custom hook that subscribes to a shopping list in our Firestore database
@@ -77,11 +77,12 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 	}
 }
 
-export async function updateItem(list, itemId) {
+export async function updateItem(list, itemId, dateNextPurchased) {
 	const docRef = doc(db, list, itemId);
 	return await updateDoc(docRef, {
 		dateLastPurchased: new Date(),
 		totalPurchases: increment(1),
+		dateNextPurchased: dateNextPurchased,
 	});
 }
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -86,7 +86,7 @@ export async function updateItem(
 	dateNextPurchased,
 	totalPurchases,
 ) {
-	const now = Date.now(); //current date
+	const now = Date.now(); //current date in ms
 	const dateLastPurchasedOrCreated = dateLastPurchased
 		? dateLastPurchased.toDate()
 		: dateCreated.toDate();
@@ -97,7 +97,7 @@ export async function updateItem(
 	);
 	const daysSinceLastTransaction = getDaysBetweenDates(
 		dateLastPurchasedOrCreated,
-		now,
+		new Date(),
 	);
 
 	const daysUntilNextPurchasedDate = calculateEstimate(

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -4,7 +4,6 @@ import React, { useState } from 'react';
 // LOCAL IMPORTS
 import './ListItem.css';
 import { updateItem } from '../api/firebase.js';
-import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 export function ListItem({
 	name,
@@ -16,67 +15,23 @@ export function ListItem({
 	dateNextPurchased,
 }) {
 	const now = Date.now() / 1000; //current time in seconds
+
 	// SET STATES
 	const [isChecked, setIsChecked] = useState(
 		now - dateLastPurchased?.seconds < 60 * 60 * 24,
 	);
 
-	// HELPER FUNCTIONS
-	const getDaysSinceLastTransaction = (dateLastPurchased, dateCreated) => {
-		const oneDay = 24 * 60 * 60; // hours * minutes * seconds
-		const lastTransactionDate = dateLastPurchased
-			? dateLastPurchased.seconds
-			: dateCreated.seconds; // Use the last purchased date if available, else use the created date
-
-		const daysSinceLastTransaction = Math.round(
-			Math.abs((now - lastTransactionDate) / oneDay),
-		);
-
-		return daysSinceLastTransaction;
-	};
-
-	// Helper fxn to calculate days between last and next purchased date
-	const getDaysBetweenLastAndNextPurchase = (
-		dateLastPurchased,
-		dateCreated,
-	) => {
-		const dateLastPurchasedSeconds = dateLastPurchased
-			? dateLastPurchased.seconds
-			: dateCreated.seconds;
-		const dateNextPurchasedSeconds = dateNextPurchased.seconds;
-
-		const daysBetweenLastAndNextPurchased = Math.round(
-			(dateNextPurchasedSeconds - dateLastPurchasedSeconds) / (60 * 60 * 24),
-		);
-
-		return daysBetweenLastAndNextPurchased;
-	};
-
-	const getNewNextPurchaseDate = (estimatedDays) => {
-		const estimatedDaysInMilliseconds = estimatedDays * 1000 * 60 * 60 * 24;
-		const newDateMilliseconds = estimatedDaysInMilliseconds + Date.now();
-		return new Date(newDateMilliseconds);
-	};
-
 	// EVENT HANDLER
 	const handleCheck = () => {
 		if (!isChecked) {
-			const daysSinceLastTransaction = getDaysSinceLastTransaction(
+			updateItem(
+				listToken,
+				itemId,
 				dateLastPurchased,
 				dateCreated,
-			);
-			const previousEstimate = getDaysBetweenLastAndNextPurchase(
-				dateLastPurchased,
-				dateCreated,
-			);
-			const estimatedDays = calculateEstimate(
-				previousEstimate,
-				daysSinceLastTransaction,
+				dateNextPurchased,
 				totalPurchases,
 			);
-			const newNextPurchaseDate = getNewNextPurchaseDate(estimatedDays);
-
-			updateItem(listToken, itemId, newNextPurchaseDate);
 		}
 		setIsChecked((prevState) => !prevState);
 	};

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -15,11 +15,25 @@ export function ListItem({
 	dateCreated,
 	dateNextPurchased,
 }) {
-	const currentDate = Date.now();
+	const now = Date.now() / 1000; //current time in seconds
 	// SET STATES
 	const [isChecked, setIsChecked] = useState(
-		Date.now() / 1000 - dateLastPurchased?.seconds < 60 * 60 * 24,
+		now - dateLastPurchased?.seconds < 60 * 60 * 24,
 	);
+
+	// Helper function to calculate days since last purchase
+	const getDaysSinceLastPurchase = (dateLastPurchased, dateCreated) => {
+		const oneDay = 24 * 60 * 60; // hours * minutes * seconds
+		const lastPurchasedDate = dateLastPurchased
+			? dateLastPurchased.seconds
+			: dateCreated.seconds; // Use the last purchased date if available, else use the created date
+
+		const daysSinceLastPurchase = Math.round(
+			Math.abs((now - lastPurchasedDate) / oneDay),
+		);
+
+		return daysSinceLastPurchase;
+	};
 
 	// EVENT HANDLER
 	const handleCheck = () => {
@@ -30,13 +44,20 @@ export function ListItem({
 					60 *
 					24,
 			);
-			console.log('date next:', dateNextPurchased);
-			console.log('date last:', dateLastPurchased);
-			console.log('between:', daysBetweenLastAndNextPurchased);
+
 			const previousEstimate =
 				dateLastPurchased === null ? 14 : daysBetweenLastAndNextPurchased;
-			const daysSinceLastTransaction = null;
+
+			const daysSinceLastTransaction = getDaysSinceLastPurchase(
+				dateLastPurchased,
+				dateCreated,
+			);
+			// console.log('date next:', dateNextPurchased);
+			// console.log('date last:', dateLastPurchased);
+			console.log('days since last transaction:', daysSinceLastTransaction);
+
 			// let estimatedDays = calculateEstimate( previousEstimate, daysSinceLastTransaction, totalPurchases);
+
 			// calculate date from estimated number of days and pass to updateItem
 			updateItem(listToken, itemId); // NEED TO PASS DATENEXTPURCHASED AS DATE, CALCULATED USING CALCULATEESTIMATE
 		}

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -35,26 +35,45 @@ export function ListItem({
 		return daysSinceLastPurchase;
 	};
 
+	// Helper fxn to calculate days between last and next purchased date
+	const getDaysBetweenLastAndNextPurchase = (
+		dateLastPurchased,
+		dateCreated,
+	) => {
+		const dateLastPurchasedJS = dateLastPurchased?.toDate(); // Convert Firestore's Timestamp object to Javascript Date object
+		const dateNextPurchasedJS = dateNextPurchased.toDate();
+		const dateLastPurchasedSeconds = dateLastPurchasedJS?.getTime() / 1000;
+		const dateNextPurchasedSeconds = dateNextPurchasedJS.getTime() / 1000;
+
+		const daysBetweenLastAndNextPurchased = Math.round(
+			Math.abs(dateNextPurchasedSeconds - dateLastPurchasedSeconds) /
+				(60 * 60 * 24),
+		);
+
+		return daysBetweenLastAndNextPurchased;
+	};
+
 	// EVENT HANDLER
 	const handleCheck = () => {
 		if (!isChecked) {
-			const daysBetweenLastAndNextPurchased = Math.round(
-				(Math.abs(dateNextPurchased.seconds - dateLastPurchased?.seconds) /
-					60) *
-					60 *
-					24,
-			);
-
-			const previousEstimate =
-				dateLastPurchased === null ? 14 : daysBetweenLastAndNextPurchased;
-
 			const daysSinceLastTransaction = getDaysSinceLastPurchase(
 				dateLastPurchased,
 				dateCreated,
 			);
-			// console.log('date next:', dateNextPurchased);
-			// console.log('date last:', dateLastPurchased);
+
+			const daysBetweenLastAndNextPurchase = getDaysBetweenLastAndNextPurchase(
+				dateLastPurchased,
+				dateCreated,
+			);
+
+			const previousEstimate =
+				dateLastPurchased === null ? 14 : daysBetweenLastAndNextPurchase;
+
 			console.log('days since last transaction:', daysSinceLastTransaction);
+			console.log(
+				'days between last and next purchased:',
+				daysBetweenLastAndNextPurchase,
+			);
 
 			// let estimatedDays = calculateEstimate( previousEstimate, daysSinceLastTransaction, totalPurchases);
 
@@ -63,8 +82,6 @@ export function ListItem({
 		}
 		setIsChecked((prevState) => !prevState);
 	};
-
-	// previousEstimate == Diff between dateNextPurchased and dateLastPurchased (if dateLast not null)
 
 	return (
 		<li className="ListItem">

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -4,8 +4,18 @@ import React, { useState } from 'react';
 // LOCAL IMPORTS
 import './ListItem.css';
 import { updateItem } from '../api/firebase.js';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
-export function ListItem({ name, listToken, dateLastPurchased, itemId }) {
+export function ListItem({
+	name,
+	listToken,
+	dateLastPurchased,
+	itemId,
+	totalPurchases,
+	dateCreated,
+	dateNextPurchased,
+}) {
+	const currentDate = Date.now();
 	// SET STATES
 	const [isChecked, setIsChecked] = useState(
 		Date.now() / 1000 - dateLastPurchased?.seconds < 60 * 60 * 24,
@@ -14,10 +24,26 @@ export function ListItem({ name, listToken, dateLastPurchased, itemId }) {
 	// EVENT HANDLER
 	const handleCheck = () => {
 		if (!isChecked) {
-			updateItem(listToken, itemId);
+			const daysBetweenLastAndNextPurchased = Math.round(
+				(Math.abs(dateNextPurchased.seconds - dateLastPurchased?.seconds) /
+					60) *
+					60 *
+					24,
+			);
+			console.log('date next:', dateNextPurchased);
+			console.log('date last:', dateLastPurchased);
+			console.log('between:', daysBetweenLastAndNextPurchased);
+			const previousEstimate =
+				dateLastPurchased === null ? 14 : daysBetweenLastAndNextPurchased;
+			const daysSinceLastTransaction = null;
+			// let estimatedDays = calculateEstimate( previousEstimate, daysSinceLastTransaction, totalPurchases);
+			// calculate date from estimated number of days and pass to updateItem
+			updateItem(listToken, itemId); // NEED TO PASS DATENEXTPURCHASED AS DATE, CALCULATED USING CALCULATEESTIMATE
 		}
 		setIsChecked((prevState) => !prevState);
 	};
+
+	// previousEstimate == Diff between dateNextPurchased and dateLastPurchased (if dateLast not null)
 
 	return (
 		<li className="ListItem">

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,11 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+
+export function getDaysBetweenDates(olderDate, newerDate) {
+	const olderDateMs = olderDate.getTime();
+	const newerDateMs = newerDate.getTime();
+	const differenceInMs = newerDateMs - olderDateMs;
+	const differenceInDays = differenceInMs / ONE_DAY_IN_MILLISECONDS;
+	return differenceInDays;
+}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -65,7 +65,16 @@ export function List({ data, listToken }) {
 						<ul>
 							{searchData &&
 								searchData.map((item) => (
-									<ListItem key={item.id} name={item.name} itemId={item.id} dateLastPurchased={item.dateLastPurchased} listToken={listToken}/>
+									<ListItem
+										key={item.id}
+										name={item.name}
+										itemId={item.id}
+										dateCreated={item.dateCreated}
+										dateLastPurchased={item.dateLastPurchased}
+										dateNextPurchased={item.dateNextPurchased}
+										totalPurchases={item.totalPurchases}
+										listToken={listToken}
+									/>
 								))}
 						</ul>
 					) : (


### PR DESCRIPTION
## Description

When the user checks an item on their list as purchased, their next purchase date will be estimated and updated in the database. 

## Related Issue
closes #10 

## Acceptance criteria
- [x] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
  - [x] `dateNextPurchased` is saved as **a date**, not a number
- [x] A `getDaysBetweenDates` function is exported from `utils/dates.js`  and imported into `api/firebase.js`
  - [x] This function takes two JavaScript Dates and return the number of days that have passed between them


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


## Testing Steps / QA Criteria

1. Run `git fetch` and `git pull` in the terminal on the main branch to retrieve all updates, then switch to feature branch with `git checkout as-jc-next-purchase`
2. Run the dev environment with `npm start`
3. In the browser, clear the list token stored in your local storage. Refresh the page and create a new list. 
4. Navigate to the Add Item page and add 2 items to your list. Navigate to the List view, where you will see your items. Note your list name from your local storage. 
5. In a new tab, navigate to Firestore and open your list. Manually change the dateCreated field of each item to 7 days before today's date. Note the current value of the dateNextPurchased for each of your items.  
7. Back in the List view of the application, check your first item once to mark it as purchased once, and check the second item twice to mark it as purchased twice. 
8. In Firestore, verify that the following 3 fields have been updated: dateLastPurchased, dateNextPurchased, and totalPurchased. For the first item, the dateLastPurchased should be the current date and time, the dateNextPurchased should be 7 days after dateLastPurchased, and totalPurchased should equal 1. For the second item, the dateLastPurchased should be the current date and time, the dateNextPurchased should equal the dateLastPurchased, and totalPurchased should equal 2.  (NOTE:  The `calculateEstimate` function defined in the `@the-collab-lab/shopping-list-utils` module contains the logic for setting the next purchase date).