### PR TITLE
Sort list by purchase urgency

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -203,10 +203,10 @@ export function comparePurchaseUrgency(data) {
 	const timeSortedItems = sortedActiveItems.concat(inactiveItems);
 
 	//TESTING
-	console.log('inactive items: ', inactiveItems);
-	console.log('active items: ', activeItems);
-	console.log('sorted active items: ', sortedActiveItems);
-	console.log('all items sorted: ', timeSortedItems);
+	// console.log('inactive items: ', inactiveItems);
+	// console.log('active items: ', activeItems);
+	// console.log('sorted active items: ', sortedActiveItems);
+	// console.log('all items sorted: ', timeSortedItems);
 	timeSortedItems.map((item) => {
 		console.log(
 			'item name',

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -201,12 +201,6 @@ export function comparePurchaseUrgency(data) {
 
 	//add the inactive elements to the end of the sorted array
 	const timeSortedItems = sortedActiveItems.concat(inactiveItems);
-
-	//TESTING
-	// console.log('inactive items: ', inactiveItems);
-	// console.log('active items: ', activeItems);
-	// console.log('sorted active items: ', sortedActiveItems);
-	// console.log('all items sorted: ', timeSortedItems);
 	timeSortedItems.map((item) => {
 		console.log(
 			'item name',

--- a/src/components/ListItem.css
+++ b/src/components/ListItem.css
@@ -12,3 +12,8 @@
 .ListItem-label {
 	margin-left: 0.2em;
 }
+.urgency-indicator {
+	border-style: solid;
+	border-width: 0.1em;
+	margin: 0.1em 1em;
+}

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -33,9 +33,8 @@ export function ListItem({
 	function getUrgency(dateLastPurchased = undefined, dateNextPurchased) {
 		const today = new Date();
 
-		const daysToNextPurchase = Math.round(getDaysBetweenDates(...
-			today,
-			dateNextPurchased.toDate(),
+		const daysToNextPurchase = Math.round(
+			getDaysBetweenDates(today, dateNextPurchased.toDate()),
 		);
 
 		if (

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -33,7 +33,7 @@ export function ListItem({
 	function getUrgency(dateLastPurchased = undefined, dateNextPurchased) {
 		const today = new Date();
 
-		const daysToNextPurchase = getDaysBetweenDates(
+		const daysToNextPurchase = Math.round(getDaysBetweenDates(...
 			today,
 			dateNextPurchased.toDate(),
 		);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -35,7 +35,7 @@ export function ListItem({
 			today,
 			dateNextPurchased.toDate(),
 		);
-		console.log('days between: ', daysToNextPurchase);
+
 		if (
 			dateLastPurchased &&
 			getDaysBetweenDates(dateLastPurchased?.toDate(), today) > 60

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -4,12 +4,53 @@ import React, { useState } from 'react';
 // LOCAL IMPORTS
 import './ListItem.css';
 import { updateItem } from '../api/firebase.js';
+import { getDaysBetweenDates } from '../utils/dates.js';
 
-export function ListItem({ name, listToken, dateLastPurchased, itemId }) {
+export function ListItem({
+	name,
+	listToken,
+	dateLastPurchased,
+	itemId,
+	dateNextPurchased,
+}) {
 	// SET STATES
 	const [isChecked, setIsChecked] = useState(
 		Date.now() / 1000 - dateLastPurchased?.seconds < 60 * 60 * 24,
 	);
+
+	//set a variable to store urgency indicator string
+	//use conditional logic to set string
+	//if today's date - last purchase date > 60
+	//else if date next purchased - today's date > 0 && < 7
+	//"soon"
+	//if date next purchased - today's date >=7 && < 30
+	//"kind of soon"
+	//if date next purchased - today's date >= 30
+	//"not soon"
+
+	function getUrgency(dateLastPurchased = undefined, dateNextPurchased) {
+		const today = new Date();
+
+		const daysToNextPurchase = getDaysBetweenDates(
+			today,
+			dateNextPurchased.toDate(),
+		);
+		console.log('days between: ', daysToNextPurchase);
+		if (
+			dateLastPurchased &&
+			getDaysBetweenDates(dateLastPurchased?.toDate(), today) > 60
+		) {
+			return 'Inactive';
+		} else if (daysToNextPurchase > 0 && daysToNextPurchase < 7) {
+			return 'Soon';
+		} else if (daysToNextPurchase >= 7 && daysToNextPurchase < 30) {
+			return 'Kind of soon';
+		} else {
+			return 'Not soon';
+		}
+	}
+
+	const urgency = getUrgency(dateLastPurchased, dateNextPurchased);
 
 	// EVENT HANDLER
 	const handleCheck = () => {
@@ -29,6 +70,7 @@ export function ListItem({ name, listToken, dateLastPurchased, itemId }) {
 				onChange={handleCheck}
 			/>
 			<label htmlFor={name}> {name} </label>
+			<div className="urgency-indicator">{urgency}</div>
 		</li>
 	);
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,11 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+
+export function getDaysBetweenDates(olderDate, newerDate) {
+	const olderDateMs = olderDate.getTime();
+	const newerDateMs = newerDate.getTime();
+	const differenceInMs = newerDateMs - olderDateMs;
+	const differenceInDays = differenceInMs / ONE_DAY_IN_MILLISECONDS;
+	return differenceInDays;
+}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -23,6 +23,10 @@ export function List({ data, listToken }) {
 	};
 
 	useEffect(() => {
+		setSearchData(comparePurchaseUrgency(data));
+	}, [data]);
+
+	useEffect(() => {
 		const searchRegex = new RegExp(
 			input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
 			'i',

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,15 +1,16 @@
 import { useState, useEffect } from 'react';
 import { ListItem } from '../components';
 import { useNavigate } from 'react-router-dom';
+import { comparePurchaseUrgency } from '../api/firebase.js';
 
 export function List({ data, listToken }) {
 	// state for input
 	const [input, setInput] = useState('');
-	const [searchData, setSearchData] = useState(data);
+	const [searchData, setSearchData] = useState(comparePurchaseUrgency(data));
 	const [isValid, setIsValid] = useState(false);
 	const [searchLength, setSearchLength] = useState(1);
 	const navigate = useNavigate();
-
+	console.log('sorted list: ', comparePurchaseUrgency(data));
 	// Handle events
 	const handleInputChange = (e) => {
 		setInput(e.target.value);
@@ -65,7 +66,14 @@ export function List({ data, listToken }) {
 						<ul>
 							{searchData &&
 								searchData.map((item) => (
-									<ListItem key={item.id} name={item.name} itemId={item.id} dateLastPurchased={item.dateLastPurchased} listToken={listToken}/>
+									<ListItem
+										key={item.id}
+										name={item.name}
+										itemId={item.id}
+										dateLastPurchased={item.dateLastPurchased}
+										dateNextPurchased={item.dateNextPurchased}
+										listToken={listToken}
+									/>
 								))}
 						</ul>
 					) : (

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -23,16 +23,12 @@ export function List({ data, listToken }) {
 	};
 
 	useEffect(() => {
-		setSearchData(comparePurchaseUrgency(data));
-	}, [data]);
-
-	useEffect(() => {
 		const searchRegex = new RegExp(
 			input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
 			'i',
 		);
 		const filteredData = data.filter((item) => searchRegex.test(item.name));
-		setSearchData(filteredData);
+		setSearchData(comparePurchaseUrgency(filteredData));
 	}, [data, input]);
 
 	useEffect(() => {


### PR DESCRIPTION
## Description

This pull request implements a feature that categorizes items into four groups based on how soon the user needs to buy them. 

We created new UI elements for user clarity and developed the logic for sorting items behind the scenes

## Related Issue

Closes #12

## Acceptance Criteria

- [x] Items in the list are shown with an indicator that tells the user they should buy the item “soon”, “kind of soon”, or “not soon”; or that the item is “inactive”
	- [x] This urgency indicator *does not* rely on only color
- [x] `api/firestore.js` exports a new `comparePurchaseUrgency` function with the following behaviors
	- [x] sorts inactive items last, then
	- [x] sorts items in ascending order of days until purchase, and
	- [x] sorts items with the same days until purchase alphabetically

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |


### Before

<img width="1399" alt="Screenshot 2023-09-20 at 10 01 13 AM" src="https://github.com/the-collab-lab/tcl-62-smart-shopping-list/assets/49603115/40a08a85-a04c-42ce-aec7-3949978c3892">

### After

<img width="1424" alt="Screenshot 2023-09-20 at 10 01 31 AM" src="https://github.com/the-collab-lab/tcl-62-smart-shopping-list/assets/49603115/ea445dac-7338-485a-8a29-3d2558065ef5">

## Testing Steps / QA Criteria

1. Go to the `main` branch in your code and get all the latest changes by using the command `git pull`. Then, switch to the `as-ms-sort-list` branch.
2. Start your development environment by running the command `npm start`.
3. Join list 'date mean hide' (**NOTE**: Please _DO NOT_ manipulate this list's data in any way so all reviewers are able to follow the following instructions)
4. In a new browser tab, navigate to the Firestore data for this list
5. Look at the list in the app, and verify that each item has an indicator showing when you should buy it. (**REMINDER**: _DO NOT_ make changes to the 'date mean hide' list as others will use it for testing)
6. Verify that the list is sorted so that the items with the closest 'next purchase date' are at the top - cross check the list order with the Firestore data (HINT: We've left a console log in that also helps verify this, so check the console but also cross-reference with Firestore)
7. Also note that the first 3 items displayed on the list all have the same next purchase date. Verify that they are displayed alphabetically in the list.
8. Further test if items are sorting correctly by clearing your local storage, creating a new list, and adding 5-6 items to the list. 
9. Change the dates of some items in your list in the Firestore database. For example, add "potatoes" and change its dateCreated: June 1, 2023 at 10:10:17 AM UTC-7, dateLastPurchased: July 2, 2023 at 1:02:55 PM UTC-7, dateNextPurchased: September 23, 2023 at 3:55:32 PM UTC-7 (more than 60 days). The item should now appear as inactive and be displayed at the end of the list.
10. To see the indicator "Not Soon", add an item like "ice cream" in Firebase and change its next purchase date in the database to a date 30+ days from today. For example, set "dateNextPurchased" to October 24, 2023, at 10:38:14 AM.
11. To check if items are sorted alphabetically, add two items to the list, for instance, "bread" and "brussels sprouts," and update the next purchase date to the same date and time for each item. Check if "bread" appears before "brussels sprouts" in the list.
12. Further verify that sorting is working by checking off a couple items on your list (which will update the next purchase date) - the list should rearrange itself accordingly.
13. Once you're done testing, please be sure to delete your newly created test list collection from Firestore to keep our database tidy!
